### PR TITLE
bqb:occursIn rw bqb:isPartOf, SemSim  ns lowercased, ontol resolved

### DIFF
--- a/BIOMD64/JWS_model/JWSOnline_Teusink.xml
+++ b/BIOMD64/JWS_model/JWSOnline_Teusink.xml
@@ -11,7 +11,7 @@
             <rdf:Description rdf:about="#metaid_1">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A15343"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:15343"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24,7 +24,7 @@
             <rdf:Description rdf:about="#metaid_2">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/28907"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:28907"/>
                   
                 </rdf:Bag>
               </bqbiol:is>
@@ -38,7 +38,7 @@
             <rdf:Description rdf:about="#metaid_3">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A16526"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:16526"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51,7 +51,7 @@
             <rdf:Description rdf:about="#metaid_4">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A16236"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:16236"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -64,7 +64,7 @@
             <rdf:Description rdf:about="#metaid_5">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/16905"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:16905"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -77,7 +77,7 @@
             <rdf:Description rdf:about="#metaid_6">
               <bqbiol:is>
                 <rdf:Bag> 
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/15946"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:15946"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -91,7 +91,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/17665"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17665"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -104,7 +104,7 @@
             <rdf:Description rdf:about="#metaid_8">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A17234"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17234"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -117,7 +117,7 @@
             <rdf:Description rdf:about="#metaid_9">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A17234"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17234"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -130,7 +130,7 @@
             <rdf:Description rdf:about="#metaid_10">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A17754"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17754"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -143,7 +143,7 @@
             <rdf:Description rdf:about="#metaid_11">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A28087"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:28087"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -156,7 +156,7 @@
             <rdf:Description rdf:about="#metaid_12">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/15846"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:15846"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -169,7 +169,7 @@
             <rdf:Description rdf:about="#metaid_13">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/16908"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:16908"/>
                   
                 </rdf:Bag>
               </bqbiol:is>
@@ -184,7 +184,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/17835"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17835"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -198,7 +198,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/17794"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:17794"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -211,7 +211,7 @@
             <rdf:Description rdf:about="#metaid_16">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/18021"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:18021"/>
                   
                 </rdf:Bag>
               </bqbiol:is>
@@ -225,7 +225,7 @@
             <rdf:Description rdf:about="#metaid_17">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/15361"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:15361"/>
                   
                 </rdf:Bag>
               </bqbiol:is>
@@ -240,7 +240,7 @@
             <rdf:Description rdf:about="#metaid_19">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A15741"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:15741"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -253,7 +253,7 @@
             <rdf:Description rdf:about="#metaid_20">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A29052"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:29052"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -266,7 +266,7 @@
             <rdf:Description rdf:about="#metaid_21">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.chebi/CHEBI%3A27082"/>
+                  <rdf:li rdf:resource="http://identifiers.org/CHEBI:27082"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1208,7 +1208,7 @@
             <rdf:Description rdf:about="#metaid_130">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0006105"/>
+                  <rdf:li rdf:resource="http://identifiers.org/GO:0006105"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1585,7 +1585,7 @@
             <rdf:Description rdf:about="#metaid_146">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="http://identifiers.org/obo.go/0006200"/>
+                  <rdf:li rdf:resource="http://identifiers.org/GO:0006200"/>
 				  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.6.1.3"/>
                 </rdf:Bag>
               </bqbiol:is>
@@ -1745,7 +1745,7 @@
             <rdf:Description rdf:about="#metaid_0000027">
               <bqbiol:isVersionOf>
 	<rdf:Bag>
-	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0005978"/>
+	<rdf:li rdf:resource="http://identifiers.org/GO:0005978"/>
 	</rdf:Bag>
 	</bqbiol:isVersionOf>
 	
@@ -1777,7 +1777,7 @@
             <rdf:Description rdf:about="#metaid_0000028">
 	<bqbiol:isVersionOf>
 	<rdf:Bag>
-	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0005992"/>
+	<rdf:li rdf:resource="http://identifiers.org/GO:0005992"/>
 	</rdf:Bag>
 	</bqbiol:isVersionOf>
 	</rdf:Description>

--- a/BIOMD64/JWS_model/JWS_Teusink_annotation.rdf
+++ b/BIOMD64/JWS_model/JWS_Teusink_annotation.rdf
@@ -1,92 +1,92 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix bqb: <http://biomodels.net/biology-qualifiers/> .
-@prefix semsim: <http://www.bhi.washington.edu/SemSim#> .
+@prefix semsim: <http://www.bhi.washington.edu/semsim#> .
 
 <#metaid_1>
     bqb:is <http://identifiers.org/CHEBI:15343> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_10>
     bqb:is <http://identifiers.org/CHEBI:17754> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_11>
     bqb:is <http://identifiers.org/CHEBI:28087> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_12>
     bqb:is <http://identifiers.org/CHEBI:15846> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_13>
     bqb:is <http://identifiers.org/CHEBI:16908> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_14>
     bqb:is <http://identifiers.org/CHEBI:17835> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_15>
     bqb:is <http://identifiers.org/CHEBI:17794> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_16>
     bqb:is <http://identifiers.org/CHEBI:18021> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_17>
     bqb:is <http://identifiers.org/CHEBI:15361> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_18>
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_19>
     bqb:is <http://identifiers.org/CHEBI:15741> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_2>
     bqb:is <http://identifiers.org/CHEBI:28907> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_20>
     bqb:is <http://identifiers.org/CHEBI:29052> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_21>
     bqb:is <http://identifiers.org/CHEBI:27082> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_22>
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_3>
     bqb:is <http://identifiers.org/CHEBI:16526> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_4>
     bqb:is <http://identifiers.org/CHEBI:16236> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_5>
     bqb:is <http://identifiers.org/CHEBI:16905> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_6>
     bqb:is <http://identifiers.org/CHEBI:15946> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_7>
     bqb:is <http://identifiers.org/CHEBI:17665> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_8>
     bqb:is <http://identifiers.org/CHEBI:17234> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#metaid_9>
     bqb:is <http://identifiers.org/CHEBI:17234> ;
-    bqb:occursIn <JWSOnline_Teusink.xml#metaid_0> .
+    bqb:isPartOf <JWSOnline_Teusink.xml#metaid_0> .
 
 <#sink0>
     semsim:hasMultiplier "1" ;
@@ -353,7 +353,7 @@
     bqb:isVersionOf <https://identifiers.org/opb/OPB_00425> .
 
 <JWSOnline_Teusink.xml#metaid_130>
-    bqb:is <http://identifiers.org/obo.go/GO:0006105> ;
+    bqb:is <http://identifiers.org/GO:0006105> ;
     semsim:hasSinkParticipant <#sink6>, <#sink7> ;
     semsim:hasSourceParticipant <#source5>, <#source6> .
 
@@ -376,7 +376,7 @@
     semsim:hasSourceParticipant <#source10>, <#source11> .
 
 <JWSOnline_Teusink.xml#metaid_146>
-    bqb:is <http://identifiers.org/ec-code/3.6.1.3>, <http://identifiers.org/obo.go/0006200> ;
+    bqb:is <http://identifiers.org/ec-code/3.6.1.3>, <http://identifiers.org/GO:0006200> ;
     semsim:hasSinkParticipant <#sink13> ;
     semsim:hasSourceParticipant <#source12> .
 


### PR DESCRIPTION
There were a few issues raised by Max that were fixed.

1. All bqb:occursIn were replaced with bqb:isPartOf throughout the rdf document

2. SemSim namespace was lowercased

3. All ontology terms within the SBML were edited to ensure they resolved to a web page.